### PR TITLE
Fix python creation script

### DIFF
--- a/src/pb_theme_creator.py
+++ b/src/pb_theme_creator.py
@@ -75,12 +75,9 @@ class Color:
 
         if len(valid_hex) == 6:
 
-            for i in enumerate(valid_hex):
-
-                current_character = valid_hex[i].lower()
-                if (current_character >= '0' and current_character <= '9') or \
-                    (current_character >= 'a' and current_character <= 'f'):
-                    is_valid = True
+            for current_character in valid_hex.lower():
+                is_valid = (current_character >= '0' and current_character <= '9') or \
+                    (current_character >= 'a' and current_character <= 'f')
 
         return is_valid
 


### PR DESCRIPTION
When running the script without these changes I get the following errors:
```
  File "pb_theme_creator.py", line 137, in <module>
  File "pb_theme_creator.py", line 22, in get_pbcolors_srgb
    self.hex_l = self._ask_hex('lightmode')
  File "pb_theme_creator.py", line 51, in _ask_hex
    is_valid = self._is_valid_hex(ask_hex)
  File "pb_theme_creator.py", line 80, in _is_valid_hex
    current_character = valid_hex[i].lower()
```

I ended up fixing this by looping over characters in the string instead, since earlier it was comparing with string[string] rather than string[index].

edited for clarity*